### PR TITLE
fix user edit page

### DIFF
--- a/Form/Type/UserType.php
+++ b/Form/Type/UserType.php
@@ -35,7 +35,7 @@ class UserType extends AbstractType
             $options['data']->getLocale(),
             \IntlDateFormatter::FULL,
             \IntlDateFormatter::FULL,
-            new \DateTimeZone($options['data']->getTimezone())
+            (new \DateTimeZone($options['data']->getTimezone()))->getName()
         );
 
         if(


### PR DESCRIPTION
As it turned out, the problem was the php version. In 5.4 the getName() is not there at var_dump, and also as __toString() method, but this way it's always get the right data
