### PR TITLE
Refactoring

### DIFF
--- a/Controller/ActivityController.php
+++ b/Controller/ActivityController.php
@@ -13,13 +13,9 @@ namespace CampaignChain\CoreBundle\Controller;
 use CampaignChain\CoreBundle\Entity\Medium;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use CampaignChain\CoreBundle\Entity\Activity;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use CampaignChain\CoreBundle\Entity\Action;
 
 class ActivityController extends Controller
@@ -255,9 +251,7 @@ class ActivityController extends Controller
 
     public function moveApiAction(Request $request)
     {
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         $responseData = array();
 
@@ -289,11 +283,10 @@ class ActivityController extends Controller
         // TODO: Check whether start = end date.
         $responseData['new_end_date'] = $responseData['new_start_date'];
 
-        $repository = $this->getDoctrine()->getManager();
-        $repository->persist($activity);
-        $repository->flush();
+        $em = $this->getDoctrine()->getManager();
+        $em->persist($activity);
+        $em->flush();
 
-        $response = new Response($serializer->serialize($responseData, 'json'));
-        return $response->setStatusCode(Response::HTTP_OK);
+        return new Response($serializer->serialize($responseData, 'json'));
     }
 }

--- a/Controller/CampaignController.php
+++ b/Controller/CampaignController.php
@@ -11,32 +11,19 @@
 namespace CampaignChain\CoreBundle\Controller;
 
 use CampaignChain\CoreBundle\Util\DateTimeUtil;
-use CampaignChain\CoreBundle\Form\Type\CampaignType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use CampaignChain\CoreBundle\Entity\Campaign;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Doctrine\ORM\EntityRepository;
-use CampaignChain\CoreBundle\Entity\Action;
 
 class CampaignController extends Controller
 {
     const FORMAT_DATEINTERVAL = 'Years: %Y, months: %m, days: %d, hours: %h, minutes: %i, seconds: %s';
 
-    public function indexAction(){
-        $repository = $this->getDoctrine()
-            ->getRepository('CampaignChainCoreBundle:Campaign');
+    public function indexAction()
+    {
 
-        $query = $repository->createQueryBuilder('campaign')
-            ->where('campaign.status != :statusBackgroundProcess')
-            ->setParameter('statusBackgroundProcess', Action::STATUS_BACKGROUND_PROCESS)
-            ->orderBy('campaign.startDate', 'DESC')
-            ->getQuery();
-
-        $repository_campaigns = $query->getResult();
+        $repository_campaigns = $this->getDoctrine()->getRepository('CampaignChainCoreBundle:Campaign')->getCampaigns();
 
         return $this->render(
             'CampaignChainCoreBundle:Campaign:index.html.twig',
@@ -52,10 +39,10 @@ class CampaignController extends Controller
             ->add('campaign_module', 'entity', array(
                 'label' => 'Type',
                 'class' => 'CampaignChainCoreBundle:CampaignModule',
-                'query_builder' => function(EntityRepository $er) {
-                        return $er->createQueryBuilder('cm')
-                            ->orderBy('cm.displayName', 'ASC');
-                    },
+                'query_builder' => function (EntityRepository $er) {
+                    return $er->createQueryBuilder('cm')
+                        ->orderBy('cm.displayName', 'ASC');
+                },
                 'property' => 'displayName',
                 'empty_value' => 'Select the type of campaign',
                 'empty_data' => null,
@@ -70,9 +57,8 @@ class CampaignController extends Controller
             $campaignModule = $campaignService->getCampaignModule($form->get('campaign_module')->getData());
 
             $routes = $campaignModule->getRoutes();
-            return $this->redirect(
-                $this->generateUrl($routes['new'])
-            );
+
+            return $this->redirectToRoute($routes['new']);
         }
 
         return $this->render(
@@ -92,14 +78,7 @@ class CampaignController extends Controller
         $campaignModule = $campaignService->getCampaignModuleByCampaign($id);
         $routes = $campaignModule->getRoutes();
 
-        return $this->redirect(
-            $this->generateUrl(
-                $routes['edit'],
-                array(
-                    'id' => $id,
-                )
-            )
-        );
+        return $this->redirectToRoute($routes['edit'], array('id' => $id));
     }
 
     public function editModalAction(Request $request, $id)
@@ -110,21 +89,13 @@ class CampaignController extends Controller
         $campaignModule = $campaignService->getCampaignModuleByCampaign($id);
         $routes = $campaignModule->getRoutes();
 
-        return $this->redirect(
-            $this->generateUrl(
-                $routes['edit_modal'],
-                array(
-                    'id' => $id,
-                )
-            )
-        );
+        return $this->redirectToRoute($routes['edit_modal'], array('id' => $id));
+
     }
 
     public function moveApiAction(Request $request)
     {
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         $responseData = array();
 
@@ -148,7 +119,6 @@ class CampaignController extends Controller
         $responseData['campaign']['new_start_date'] = $campaign->getStartDate()->format(\DateTime::ISO8601);
         $responseData['campaign']['new_end_date'] = $campaign->getEndDate()->format(\DateTime::ISO8601);
 
-        $response = new Response($serializer->serialize($responseData, 'json'));
-        return $response->setStatusCode(Response::HTTP_OK);
+        return new Response($serializer->serialize($responseData, 'json'));
     }
 }

--- a/Controller/ChannelController.php
+++ b/Controller/ChannelController.php
@@ -15,9 +15,6 @@ use CampaignChain\CoreBundle\Entity\Channel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Doctrine\ORM\EntityRepository;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
 class ChannelController extends Controller
 {
@@ -125,10 +122,7 @@ class ChannelController extends Controller
             }
 //        }
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         return new Response($serializer->serialize($response, 'json'));
     }
@@ -180,10 +174,7 @@ class ChannelController extends Controller
 
         $response['ok'] = $trackingStatus;
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         return new Response($serializer->serialize($response, 'json'));
     }

--- a/Controller/DevelopmentController.php
+++ b/Controller/DevelopmentController.php
@@ -216,8 +216,8 @@ class DevelopmentController extends Controller
             $entity->setStartDate($hook->getStartDate());
             $entity->setEndDate($hook->getEndDate());
 
-            $repository = $this->getDoctrine()->getManager();
-            $repository->persist($entity);
+            $em = $this->getDoctrine()->getManager();
+            $em->persist($entity);
         }
     }
 

--- a/Controller/LocationController.php
+++ b/Controller/LocationController.php
@@ -15,10 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use CampaignChain\CoreBundle\Entity\Channel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Doctrine\ORM\EntityRepository;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 
 class LocationController extends Controller
 {
@@ -78,10 +74,7 @@ class LocationController extends Controller
             }
 //        }
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         return new Response($serializer->serialize($response, 'json'));
     }

--- a/Controller/MilestoneController.php
+++ b/Controller/MilestoneController.php
@@ -10,15 +10,10 @@
 
 namespace CampaignChain\CoreBundle\Controller;
 
-use CampaignChain\CoreBundle\Form\Type\MilestoneType;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use CampaignChain\CoreBundle\Entity\Milestone;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Doctrine\ORM\EntityRepository;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use CampaignChain\CoreBundle\Entity\Action;
 
 class MilestoneController extends Controller
@@ -134,9 +129,7 @@ class MilestoneController extends Controller
 
     public function moveApiAction(Request $request)
     {
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         $responseData = array();
 
@@ -160,11 +153,10 @@ class MilestoneController extends Controller
         $milestone = $milestoneService->moveMilestone($milestone, $interval);
         $responseData['new_due_date'] = $milestone->getStartDate()->format(\DateTime::ISO8601);
 
-        $repository = $this->getDoctrine()->getManager();
-        $repository->flush();
+        $em = $this->getDoctrine()->getManager();
+        $em->flush();
 
-        $response = new Response($serializer->serialize($responseData, 'json'));
-        return $response->setStatusCode(Response::HTTP_OK);
+        return new Response($serializer->serialize($responseData, 'json'));
     }
     public function  removeAction(Request $request, $id)
     {

--- a/Controller/ReportController.php
+++ b/Controller/ReportController.php
@@ -13,9 +13,6 @@ namespace CampaignChain\CoreBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use CampaignChain\CoreBundle\Entity\Report;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\HttpFoundation\Response;
 
 class ReportController extends Controller
@@ -75,10 +72,7 @@ class ReportController extends Controller
             );
         }
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-
-        $serializer = new Serializer($normalizers, $encoders);
+        $serializer = $this->get('campaignchain.core.serializer.default');
 
         return new Response($serializer->serialize($response, 'json'));
     }

--- a/Controller/TrackingController.php
+++ b/Controller/TrackingController.php
@@ -219,9 +219,9 @@ class TrackingController extends Controller
             }
             $reportCTA->setTime();
 
-            $repository = $this->getDoctrine()->getManager();
-            $repository->persist($reportCTA);
-            $repository->flush();
+            $em = $this->getDoctrine()->getManager();
+            $em->persist($reportCTA);
+            $em->flush();
 
             $logger->info('-------');
             $logger->info('Tracking data:');

--- a/Entity/ActivityModule.php
+++ b/Entity/ActivityModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/CampaignModule.php
+++ b/Entity/CampaignModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/ChannelModule.php
+++ b/Entity/ChannelModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/LocationModule.php
+++ b/Entity/LocationModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/MilestoneModule.php
+++ b/Entity/MilestoneModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/OperationModule.php
+++ b/Entity/OperationModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/ReportModule.php
+++ b/Entity/ReportModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/Entity/SecurityModule.php
+++ b/Entity/SecurityModule.php
@@ -11,7 +11,6 @@
 namespace CampaignChain\CoreBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use CampaignChain\CoreBundle\Entity\Module;
 
 /**
  * @ORM\Entity

--- a/EntityService/CampaignService.php
+++ b/EntityService/CampaignService.php
@@ -12,23 +12,23 @@ namespace CampaignChain\CoreBundle\EntityService;
 
 use CampaignChain\CoreBundle\Entity\Hook;
 use Doctrine\ORM\EntityManager;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use CampaignChain\CoreBundle\Entity\Action;
 use CampaignChain\CoreBundle\Entity\Campaign;
 use CampaignChain\CoreBundle\Twig\CampaignChainCoreExtension;
+use Symfony\Component\Serializer\SerializerInterface;
 
 class CampaignService
 {
     protected $em;
     protected $container;
+    protected $serializer;
 
-    public function __construct(EntityManager $em, ContainerInterface $container)
+    public function __construct(EntityManager $em, ContainerInterface $container, SerializerInterface $serializer)
     {
         $this->em = $em;
         $this->container = $container;
+        $this->serializer = $serializer;
     }
 
     public function getAllCampaigns(){
@@ -105,11 +105,7 @@ class CampaignService
             );
         }
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $serializer = new Serializer($normalizers, $encoders);
-
-        return $serializer->serialize($campaignsDates, 'json');
+        return $this->serializer->serialize($campaignsDates, 'json');
     }
 
     public function moveCampaign(Campaign $campaign, $newStartDate, $status = null){

--- a/Model/DhtmlxGantt.php
+++ b/Model/DhtmlxGantt.php
@@ -11,10 +11,8 @@
 namespace CampaignChain\CoreBundle\Model;
 
 use Doctrine\ORM\EntityManager;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 class DhtmlxGantt
 {
@@ -22,11 +20,13 @@ class DhtmlxGantt
 
     protected $em;
     protected $container;
+    protected $serializer;
 
-    public function __construct(EntityManager $em, ContainerInterface $container)
+    public function __construct(EntityManager $em, ContainerInterface $container, SerializerInterface $serializer)
     {
         $this->em = $em;
         $this->container = $container;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -246,11 +246,6 @@ class DhtmlxGantt
             exit;
         }
 
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-
-        $serializer = new Serializer($normalizers, $encoders);
-
-        return $serializer->serialize($ganttTasks, 'json');
+        return $this->serializer->serialize($ganttTasks, 'json');
     }
 }

--- a/Model/FullCalendar.php
+++ b/Model/FullCalendar.php
@@ -11,10 +11,8 @@
 namespace CampaignChain\CoreBundle\Model;
 
 use Doctrine\ORM\EntityManager;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 class FullCalendar
 {
@@ -22,19 +20,17 @@ class FullCalendar
 
     protected $em;
     protected $container;
+    protected $serializer;
 
-    public function __construct(EntityManager $em, ContainerInterface $container)
+    public function __construct(EntityManager $em, ContainerInterface $container, SerializerInterface $serializer)
     {
         $this->em = $em;
         $this->container = $container;
+        $this->serializer = $serializer;
     }
 
     public function getEvents($bundleName = null, $moduleIdentifier = null, $campaignId = null){
         $calendarEvents = array();
-
-        $encoders = array(new JsonEncoder());
-        $normalizers = array(new GetSetMethodNormalizer());
-        $serializer = new Serializer($normalizers, $encoders);
 
         $qb = $this->em->createQueryBuilder();
         $qb->select('c')
@@ -117,21 +113,21 @@ class FullCalendar
         }
 
         if(isset($campaignEvents['ongoing'])){
-            $calendarEvents['campaign_ongoing']['data'] = $serializer->serialize($campaignEvents['ongoing'], 'json');
+            $calendarEvents['campaign_ongoing']['data'] = $this->serializer->serialize($campaignEvents['ongoing'], 'json');
             $calendarEvents['campaign_ongoing']['options'] = array(
                 'className' => 'campaignchain-calendar-ongoing campaignchain-calendar-campaign',
                 'startEditable' => false,
             );
         }
         if(isset($campaignEvents['done'])){
-            $calendarEvents['campaign_done']['data'] = $serializer->serialize($campaignEvents['done'], 'json');
+            $calendarEvents['campaign_done']['data'] = $this->serializer->serialize($campaignEvents['done'], 'json');
             $calendarEvents['campaign_done']['options'] = array(
                 'className' => 'campaignchain-calendar-done campaignchain-calendar-campaign',
                 'editable' => false,
             );
         }
         if(isset($campaignEvents['upcoming'])){
-            $calendarEvents['campaign_upcoming']['data'] = $serializer->serialize($campaignEvents['upcoming'], 'json');
+            $calendarEvents['campaign_upcoming']['data'] = $this->serializer->serialize($campaignEvents['upcoming'], 'json');
             $calendarEvents['campaign_upcoming']['options'] = array(
                 'className' => 'campaignchain-calendar-upcoming campaignchain-calendar-campaign',
                 'startEditable' => false,
@@ -173,14 +169,14 @@ class FullCalendar
             }
 
             if(isset($activityEvents['done'])){
-                $calendarEvents['activity_done']['data'] = $serializer->serialize($activityEvents['done'], 'json');
+                $calendarEvents['activity_done']['data'] = $this->serializer->serialize($activityEvents['done'], 'json');
                 $calendarEvents['activity_done']['options'] = array(
                     'className' => 'campaignchain-activity campaignchain-activity-done',
                     'editable' => false,
                 );
             }
             if(isset($activityEvents['upcoming'])){
-                $calendarEvents['activity_upcoming']['data'] = $serializer->serialize($activityEvents['upcoming'], 'json');
+                $calendarEvents['activity_upcoming']['data'] = $this->serializer->serialize($activityEvents['upcoming'], 'json');
                 $calendarEvents['activity_upcoming']['options'] = array(
                     'className' => 'campaignchain-activity',
                     'durationEditable' => false,
@@ -224,14 +220,14 @@ class FullCalendar
             }
 
             if(isset($milestoneEvents['done'])){
-                $calendarEvents['milestone_done']['data'] = $serializer->serialize($milestoneEvents['done'], 'json');
+                $calendarEvents['milestone_done']['data'] = $this->serializer->serialize($milestoneEvents['done'], 'json');
                 $calendarEvents['milestone_done']['options'] = array(
                     'className' => 'campaignchain-milestone campaignchain-milestone-done',
                     'editable' => false,
                 );
             }
             if(isset($milestoneEvents['upcoming'])){
-                $calendarEvents['milestone_upcoming']['data'] = $serializer->serialize($milestoneEvents['upcoming'], 'json');
+                $calendarEvents['milestone_upcoming']['data'] = $this->serializer->serialize($milestoneEvents['upcoming'], 'json');
                 $calendarEvents['milestone_upcoming']['options'] = array(
                     'className' => 'campaignchain-milestone',
                     'durationEditable' => false,

--- a/Repository/CampaignRepository.php
+++ b/Repository/CampaignRepository.php
@@ -46,7 +46,7 @@ class CampaignRepository extends EntityRepository
 
         return $this->createQueryBuilder('campaign')
             ->select('campaign')
-            ->leftJoin('campaign.campaignModule', 'module', 'WITH', 'module.identifier = :moduleIdentifier')
+            ->Join('campaign.campaignModule', 'module', 'WITH', 'module.identifier = :moduleIdentifier')
             ->setParameter('moduleIdentifier', $moduleIdentifier)
             ->orderBy('campaign.name', 'ASC')
             ->getQuery()

--- a/Repository/CampaignRepository.php
+++ b/Repository/CampaignRepository.php
@@ -40,14 +40,17 @@ class CampaignRepository extends EntityRepository
 
     /**
      * @param $moduleIdentifier
+     * @param $bundleName
      * @return array
      */
-    public function getCampaignsByModule($moduleIdentifier) {
+    public function getCampaignsByModule($moduleIdentifier, $bundleName) {
 
         return $this->createQueryBuilder('campaign')
             ->select('campaign')
             ->Join('campaign.campaignModule', 'module', 'WITH', 'module.identifier = :moduleIdentifier')
+            ->Join('module.bundle', 'bundle', 'WITH', 'bundle.name = :bundleName')
             ->setParameter('moduleIdentifier', $moduleIdentifier)
+            ->setParameter('bundleName', $bundleName)
             ->orderBy('campaign.name', 'ASC')
             ->getQuery()
             ->getResult();

--- a/Repository/CampaignRepository.php
+++ b/Repository/CampaignRepository.php
@@ -16,8 +16,42 @@ use CampaignChain\CoreBundle\Entity\Job;
 use DateTime;
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * Class CampaignRepository
+ * @package CampaignChain\CoreBundle\Repository
+ */
 class CampaignRepository extends EntityRepository
 {
+
+    /**
+     * get a list of all campaigns
+     *
+     * @return array
+     */
+    public function getCampaigns() {
+
+        return $this->createQueryBuilder('campaign')
+            ->where('campaign.status != :statusBackgroundProcess')
+            ->setParameter('statusBackgroundProcess', Action::STATUS_BACKGROUND_PROCESS)
+            ->orderBy('campaign.startDate', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @param $moduleIdentifier
+     * @return array
+     */
+    public function getCampaignsByModule($moduleIdentifier) {
+
+        return $this->createQueryBuilder('campaign')
+            ->select('campaign')
+            ->leftJoin('campaign.campaignModule', 'module', 'WITH', 'module.identifier = :moduleIdentifier')
+            ->setParameter('moduleIdentifier', $moduleIdentifier)
+            ->orderBy('campaign.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
 
     /**
      * @param DateTime $periodStart

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -161,6 +161,7 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@service_container'
+            - '@campaignchain.core.serializer.default'
 
     campaignchain.core.milestone:
         class: CampaignChain\CoreBundle\EntityService\MilestoneService
@@ -241,12 +242,14 @@ services:
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@service_container'
+            - '@campaignchain.core.serializer.default'
 
     campaignchain.core.model.fullcalendar:
         class: CampaignChain\CoreBundle\Model\FullCalendar
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@service_container'
+            - '@campaignchain.core.serializer.default'
 
     # Sonata
     campaignchain.block.campaign.ongoing.listgroup:
@@ -391,6 +394,21 @@ services:
             - '@knp_menu.matcher'
         tags:
             - { name: knp_menu.renderer, alias: dropdown }
+
+    # Serializer
+    campaignchain.core.serializer.encoder.json:
+        class: 'Symfony\Component\Serializer\Encoder\JsonEncoder'
+
+    campaignchain.core.serializer.normalizer.getsetmethod:
+        class: 'Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer'
+
+    campaignchain.core.serializer.default:
+        class: 'Symfony\Component\Serializer\Serializer'
+        arguments:
+            0:
+                - '@campaignchain.core.serializer.normalizer.getsetmethod'
+            1:
+                - '@campaignchain.core.serializer.encoder.json'
 
     # Logger
     campaignchain.core.monolog_psr_processor:


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default